### PR TITLE
Camera improvement - expose flipCamera method

### DIFF
--- a/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
@@ -35,6 +35,7 @@ import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.google.common.util.concurrent.ListenableFuture
 import com.kylecorry.andromeda.core.sensors.AbstractSensor
 import com.kylecorry.andromeda.core.tryOrDefault
@@ -44,6 +45,7 @@ import com.kylecorry.andromeda.core.units.PixelCoordinate
 import com.kylecorry.andromeda.permissions.Permissions
 import com.kylecorry.sol.math.Range
 import com.kylecorry.sol.math.SolMath.toDegrees
+import kotlinx.coroutines.launch
 import java.io.File
 import java.io.OutputStream
 import java.time.Duration
@@ -121,7 +123,6 @@ class Camera(
             return
         }
 
-        cameraProvider?.unbindAll()
         cameraProviderFuture = ProcessCameraProvider.getInstance(context)
         cameraProviderFuture?.addListener({
             try {
@@ -220,7 +221,11 @@ class Camera(
                 CameraSelector.DEFAULT_BACK_CAMERA
             else
                 CameraSelector.DEFAULT_FRONT_CAMERA
-            startImpl()
+
+            lifecycleOwner.lifecycleScope.launch {
+                stopImpl()
+                startImpl()
+            }
         }
     }
 

--- a/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
@@ -19,12 +19,20 @@ import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.camera2.interop.Camera2Interop
 import androidx.camera.camera2.interop.CaptureRequestOptions
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
-import androidx.camera.core.*
+import androidx.camera.core.AspectRatio
 import androidx.camera.core.Camera
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.FocusMeteringAction
+import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888
 import androidx.camera.core.ImageAnalysis.OUTPUT_IMAGE_FORMAT_YUV_420_888
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.LifecycleOwner
@@ -45,6 +53,7 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.math.atan
+
 
 class Camera(
     private val context: Context,
@@ -112,6 +121,8 @@ class Camera(
         if (!Permissions.isCameraEnabled(context)) {
             return
         }
+
+        cameraProvider?.unbindAll()
 
         cameraProviderFuture = ProcessCameraProvider.getInstance(context)
         cameraProviderFuture?.addListener({

--- a/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
@@ -216,15 +216,17 @@ class Camera(
     }
 
     override fun flipCamera() {
-        cameraSelector?.let {
-            cameraSelector = if (cameraSelector === CameraSelector.DEFAULT_FRONT_CAMERA)
-                CameraSelector.DEFAULT_BACK_CAMERA
-            else
-                CameraSelector.DEFAULT_FRONT_CAMERA
+        cameraProvider?.let {
+            cameraSelector?.let {
+                cameraSelector = if (cameraSelector === CameraSelector.DEFAULT_FRONT_CAMERA)
+                    CameraSelector.DEFAULT_BACK_CAMERA
+                else
+                    CameraSelector.DEFAULT_FRONT_CAMERA
 
-            lifecycleOwner.lifecycleScope.launch {
-                stopImpl()
-                startImpl()
+                lifecycleOwner.lifecycleScope.launch {
+                    stopImpl()
+                    startImpl()
+                }
             }
         }
     }

--- a/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
@@ -94,6 +94,7 @@ class Camera(
     private var cameraProvider: ProcessCameraProvider? = null
     private var camera: Camera? = null
     private var imageCapture: ImageCapture? = null
+    private var cameraSelector: CameraSelector? = null
 
     private var _hasValidReading = false
 
@@ -183,14 +184,15 @@ class Camera(
                 imageCapture = null
             }
 
-            val cameraSelector =
-                if (isBackCamera) CameraSelector.DEFAULT_BACK_CAMERA else CameraSelector.DEFAULT_FRONT_CAMERA
+            if(cameraSelector == null){
+                cameraSelector = if (isBackCamera) CameraSelector.DEFAULT_BACK_CAMERA else CameraSelector.DEFAULT_FRONT_CAMERA
+            }
 
             preview?.setSurfaceProvider(previewView?.surfaceProvider)
 
             camera = cameraProvider?.bindToLifecycle(
                 lifecycleOwner,
-                cameraSelector,
+                cameraSelector ?: CameraSelector.DEFAULT_BACK_CAMERA,
                 *listOfNotNull(
                     if (previewView != null) preview else null,
                     if (analyze) imageAnalysis else null,
@@ -201,6 +203,16 @@ class Camera(
             notifyListeners()
         }, ContextCompat.getMainExecutor(context))
 
+    }
+
+    override fun flipCamera() {
+        cameraSelector?.let {
+            cameraSelector = if (cameraSelector === CameraSelector.DEFAULT_FRONT_CAMERA)
+                CameraSelector.DEFAULT_BACK_CAMERA
+            else
+                CameraSelector.DEFAULT_FRONT_CAMERA
+            startImpl()
+        }
     }
 
     override fun stopImpl() {

--- a/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/Camera.kt
@@ -32,7 +32,6 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.LifecycleOwner
@@ -123,7 +122,6 @@ class Camera(
         }
 
         cameraProvider?.unbindAll()
-
         cameraProviderFuture = ProcessCameraProvider.getInstance(context)
         cameraProviderFuture?.addListener({
             try {

--- a/camera/src/main/java/com/kylecorry/andromeda/camera/ICamera.kt
+++ b/camera/src/main/java/com/kylecorry/andromeda/camera/ICamera.kt
@@ -24,6 +24,8 @@ interface ICamera : ISensor {
     fun setExposure(index: Int)
     fun setTorch(isOn: Boolean)
 
+    fun flipCamera()
+
     /**
      * Get the field of view of the camera in degrees (horizontal, vertical) if available.
      * The FOV direction is based on when the phone is in portrait mode.


### PR DESCRIPTION
I added the `flipCamera` method to allow the library to expose a method that internally deals with changing the camera.
The purpose of this implementation is to realise the solution indicated in this in the Trail-sense issue https://github.com/kylecorry31/Trail-Sense/issues/1202